### PR TITLE
Fix catCodes in packUtil

### DIFF
--- a/Python/bin/packUtil.py
+++ b/Python/bin/packUtil.py
@@ -159,7 +159,17 @@ catCodes = { ' ': 'UNK',
              'T': 'URAT2',  # URAT2 missing on ADES web page
              'U': 'Gaia1',
              'V': 'Gaia2',
-             'W': 'UCAC5',  # UCAC5 mission on ADES web page
+             'W': 'Gaia3',
+             'X': 'Gaia3E',  
+             'Y': 'UCAC5',  # UCAC5 mission on ADES web page
+             'Z': 'ATLAS2', 
+             '0': 'IHW', 
+             '1': 'PS1_DR1', 
+             '2': 'PS1_DR2', 
+             '3': 'Gaia_Int', 
+             '4': 'GZ', 
+             '5': 'UBSC', 
+             '6': 'Gaia_2016', 
            }
 
 rCatCodes = { catCodes[i]:i for i in catCodes }


### PR DESCRIPTION
Addresses issue #21 

Modifies the `catCodes` dictionary in `packUtil.py` to include missing catalog codes and fix an incorrect mapping.

Supporting documentation for the correct mapping is found here:
- ADES field values: https://www.minorplanetcenter.net/iau/info/ADESFieldValues.html
- MPC catalog codes: https://www.minorplanetcenter.net/iau/info/CatalogueCodes.html

The only mapping that is ambiguous is: 
- MPC code 5 --> USNO-UBAD
- USNO-UBAD = USNO Bright-Star Astrometric Database =? USNO Bright-star Catalog 
- USNO Bright-star Catalog --> ADES field UBSC

@federicaspoto who can review/approve this?