### PR TITLE
Occultations

### DIFF
--- a/Python/bin/xmltompc80col.py
+++ b/Python/bin/xmltompc80col.py
@@ -163,8 +163,15 @@ def printOpticalLine(item):
    precRa = float(hasKeyOrVal(item, 'precRA', defaultPrecRA) )
    precDec = float(hasKeyOrVal(item, 'precDec', defaultPrecDec) )
    sexDate = sexVals.isoToSexDate(item['obsTime'], precTime)
-   sexRa = sexVals.decRaToSexRa(item['ra'], precRa)
-   sexDecl = sexVals.degDeclToSexDecl(item['dec'], precDec)
+   if(item['stn'] == '275'):
+      sexRa = sexVals.decRaToSexRa(item['raStar'], precRa)
+      sexDecl = sexVals.degDeclToSexDecl(item['decStar'], precDec)  
+   elif(item['stn'] == '244'): #This has not been tested because at the moment we don't have any data 
+      sexRa = sexVals.decRaToSexRa(item['raStar']+item['deltaRA'], precRa)
+      sexDecl = sexVals.degDeclToSexDecl(item['decStar']+item['deltaDec'], precDec)
+   else:
+      sexRa = sexVals.decRaToSexRa(item['ra'], precRa)
+      sexDecl = sexVals.degDeclToSexDecl(item['dec'], precDec)
    #mag = "{0:5s}".format(hasKeyOrVal(item, 'mag', ''))
    mag = adesutility.applyPaddingAndJustification(hasKeyOrVal(item, 'mag', ''), 5, 'D', 3)[0]
    mag = mag[0:5] # restrict to length of 5
@@ -335,7 +342,7 @@ def printDataDicts():
       #
       for subDict in dataDicts :
         eType = subDict[0]
-        if eType == 'optical':  # process optical -- may be rover or converted offset or occultation
+        if eType == 'optical' or eType == 'occultation':  # process optical -- may be rover or converted offset or occultation
            printOpticalLine(subDict[1])
         elif eType == 'radar':  # process radar
            printRadarLine(subDict[1])

--- a/new_tests/input/319.psv
+++ b/new_tests/input/319.psv
@@ -1,0 +1,56 @@
+# version=2022
+# observatory
+! mpcCode 275
+# submitter
+! name D. Herald, 3 Lupin Pl., Murrumbateman, NSW, 2582, Australia
+# measurers
+! name D. Herald
+! name N. Carlson
+! name E. Frappa
+! name D. Gault
+! name B. Giacchini
+! name T. Hayamizu
+! name S. Kerr
+! name J. Moore
+# observers
+! name S. Alonso
+! name J. Bradshaw
+! name J. Broughton
+! name F. Casarramona
+! name A. Castillo
+! name V. Dekert
+! name J. Delgado
+! name P. Escamilla
+! name R. Farfan
+! name J. Fernandez
+! name J. Flores
+! name R. Goncalves
+! name H. Hamanowa
+! name K. Kitazaki
+! name J. Madiedo
+! name J. Maestre
+! name J. Marti
+! name S. Moral
+! name N. Morales
+! name V. Pelenjow
+! name C. Perello
+! name J. Rizos
+! name A. Roman
+! name J. Rovira
+! name M. Sanchez
+! name C. Schnabel
+! name A. Selva
+! name E. Smith
+! name H. Takashima
+! name H. Tomioka
+! name R. Venable
+# telescope
+! design reflector
+! aperture 0.30
+! fRatio 9.0
+! detector CCD
+permID    |provID           |mode|stn|obsTime                |raStar       |decStar      |deltaRA |deltaDec|sys    |ctr|pos1     |pos2     |pos3     |rmsRA |rmsDec|rmsCorr|astCat  |shapeOcc|remarks                                            
+       319|                 | OCC|275|2010-10-22T12:22:12.59Z| 36.443232822|  5.964539565|  0.0000|  0.0000|ICRF_KM|399| 1833.310|-1882.459|-3409.399|0.0129|0.0157| -0.874|  Gaia3E|0       |StarUncert 0.00011, 0.00009; Fit f4;
+       319|                 | OCC|275|2010-10-27T10:58:34.73Z| 35.625268707|  5.332470663|  0.0000|  0.0000|ICRF_KM|399| 2157.966|-3582.993| 3569.948|0.0143|0.0169| -0.581|  Gaia3E|0       |StarUncert 0.00014, 0.00011; Fit f4;
+       319|                 | OCC|275|2023-09-13T03:43:27.05Z| 85.552205093| 14.001140989|  0.0000|  0.0000|ICRF_KM|399| 3336.196| -948.022| 2752.627|0.0022|0.0018| -0.095|  Gaia3E|0       |StarUncert 0.00016, 0.00010; Fit e5;
+       319|                 | OCC|275|2023-09-16T10:09:34.70Z| 86.432366700| 13.793487153|  0.0000|  0.0000|ICRF_KM|399| 3961.373| -887.256| 2602.687|0.0021|0.0018| -0.086|  Gaia3E|0       |StarUncert 0.00030, 0.00021; Fit e5;

--- a/new_tests/input/319.xml
+++ b/new_tests/input/319.xml
@@ -1,0 +1,148 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ades version="2022">
+  <obsBlock>
+    <obsContext>
+      <observatory>
+        <mpcCode>275</mpcCode>
+      </observatory>
+      <submitter>
+        <name>D. Herald, 3 Lupin Pl., Murrumbateman, NSW, 2582, Australia</name>
+      </submitter>
+      <measurers>
+        <name>D. Herald</name>
+        <name>N. Carlson</name>
+        <name>E. Frappa</name>
+        <name>D. Gault</name>
+        <name>B. Giacchini</name>
+        <name>T. Hayamizu</name>
+        <name>S. Kerr</name>
+        <name>J. Moore</name>
+      </measurers>
+      <observers>
+        <name>S. Alonso</name>
+        <name>J. Bradshaw</name>
+        <name>J. Broughton</name>
+        <name>F. Casarramona</name>
+        <name>A. Castillo</name>
+        <name>V. Dekert</name>
+        <name>J. Delgado</name>
+        <name>P. Escamilla</name>
+        <name>R. Farfan</name>
+        <name>J. Fernandez</name>
+        <name>J. Flores</name>
+        <name>R. Goncalves</name>
+        <name>H. Hamanowa</name>
+        <name>K. Kitazaki</name>
+        <name>J. Madiedo</name>
+        <name>J. Maestre</name>
+        <name>J. Marti</name>
+        <name>S. Moral</name>
+        <name>N. Morales</name>
+        <name>V. Pelenjow</name>
+        <name>C. Perello</name>
+        <name>J. Rizos</name>
+        <name>A. Roman</name>
+        <name>J. Rovira</name>
+        <name>M. Sanchez</name>
+        <name>C. Schnabel</name>
+        <name>A. Selva</name>
+        <name>E. Smith</name>
+        <name>H. Takashima</name>
+        <name>H. Tomioka</name>
+        <name>R. Venable</name>
+      </observers>
+      <telescope>
+        <design>reflector</design>
+        <aperture>0.30</aperture>
+        <fRatio>9.0</fRatio>
+        <detector>CCD</detector>
+      </telescope>
+    </obsContext>
+    <obsData>
+      <occultation>
+        <permID>319</permID>
+        <mode>OCC</mode>
+        <stn>275</stn>
+        <sys>ICRF_KM</sys>
+        <ctr>399</ctr>
+        <pos1>1833.310</pos1>
+        <pos2>-1882.459</pos2>
+        <pos3>-3409.399</pos3>
+        <obsTime>2010-10-22T12:22:12.59Z</obsTime>
+        <raStar>36.443232822</raStar>
+        <decStar>5.964539565</decStar>
+        <deltaRA>0.0000</deltaRA>
+        <deltaDec>0.0000</deltaDec>
+        <rmsRA>0.0129</rmsRA>
+        <rmsDec>0.0157</rmsDec>
+        <rmsCorr>-0.874</rmsCorr>
+        <astCat>Gaia3E</astCat>
+        <shapeOcc>0</shapeOcc>
+        <remarks>StarUncert 0.00011, 0.00009; Fit f4;</remarks>
+      </occultation>
+      <occultation>
+        <permID>319</permID>
+        <mode>OCC</mode>
+        <stn>275</stn>
+        <sys>ICRF_KM</sys>
+        <ctr>399</ctr>
+        <pos1>2157.966</pos1>
+        <pos2>-3582.993</pos2>
+        <pos3>3569.948</pos3>
+        <obsTime>2010-10-27T10:58:34.73Z</obsTime>
+        <raStar>35.625268707</raStar>
+        <decStar>5.332470663</decStar>
+        <deltaRA>0.0000</deltaRA>
+        <deltaDec>0.0000</deltaDec>
+        <rmsRA>0.0143</rmsRA>
+        <rmsDec>0.0169</rmsDec>
+        <rmsCorr>-0.581</rmsCorr>
+        <astCat>Gaia3E</astCat>
+        <shapeOcc>0</shapeOcc>
+        <remarks>StarUncert 0.00014, 0.00011; Fit f4;</remarks>
+      </occultation>
+      <occultation>
+        <permID>319</permID>
+        <mode>OCC</mode>
+        <stn>275</stn>
+        <sys>ICRF_KM</sys>
+        <ctr>399</ctr>
+        <pos1>3336.196</pos1>
+        <pos2>-948.022</pos2>
+        <pos3>2752.627</pos3>
+        <obsTime>2023-09-13T03:43:27.05Z</obsTime>
+        <raStar>85.552205093</raStar>
+        <decStar>14.001140989</decStar>
+        <deltaRA>0.0000</deltaRA>
+        <deltaDec>0.0000</deltaDec>
+        <rmsRA>0.0022</rmsRA>
+        <rmsDec>0.0018</rmsDec>
+        <rmsCorr>-0.095</rmsCorr>
+        <astCat>Gaia3E</astCat>
+        <shapeOcc>0</shapeOcc>
+        <remarks>StarUncert 0.00016, 0.00010; Fit e5;</remarks>
+      </occultation>
+      <occultation>
+        <permID>319</permID>
+        <mode>OCC</mode>
+        <stn>275</stn>
+        <sys>ICRF_KM</sys>
+        <ctr>399</ctr>
+        <pos1>3961.373</pos1>
+        <pos2>-887.256</pos2>
+        <pos3>2602.687</pos3>
+        <obsTime>2023-09-16T10:09:34.70Z</obsTime>
+        <raStar>86.432366700</raStar>
+        <decStar>13.793487153</decStar>
+        <deltaRA>0.0000</deltaRA>
+        <deltaDec>0.0000</deltaDec>
+        <rmsRA>0.0021</rmsRA>
+        <rmsDec>0.0018</rmsDec>
+        <rmsCorr>-0.086</rmsCorr>
+        <astCat>Gaia3E</astCat>
+        <shapeOcc>0</shapeOcc>
+        <remarks>StarUncert 0.00030, 0.00021; Fit e5;</remarks>
+      </occultation>
+    </obsData>
+  </obsBlock>
+</ades>

--- a/new_tests/test_occultations.py
+++ b/new_tests/test_occultations.py
@@ -1,0 +1,16 @@
+'''
+Test occultations 
+'''
+
+#Import global
+import os
+import subprocess
+
+#Test conversion from psv to xml
+def test_psv_to_xml():
+    psvfile = "input/319.psv"
+    xmlfile = "output/319.xml"
+    if os.path.exists(xmlfile):
+        os.remove(xmlfile)
+    subprocess.run("python3 ../Python/bin/psvtoxml.py "+psvfile+" "+xmlfile,shell=True)
+    assert(os.path.exists(xmlfile) and os.stat(xmlfile).st_size != 0)

--- a/new_tests/test_occultations.py
+++ b/new_tests/test_occultations.py
@@ -14,3 +14,12 @@ def test_psv_to_xml():
         os.remove(xmlfile)
     subprocess.run("python3 ../Python/bin/psvtoxml.py "+psvfile+" "+xmlfile,shell=True)
     assert(os.path.exists(xmlfile) and os.stat(xmlfile).st_size != 0)
+    
+#Test conversion from xml to obs80
+def test_xml_to_obs80():
+    xmlfile = "input/319.xml"
+    obsfile = "output/319.obs"
+    if os.path.exists(obsfile):
+        os.remove(obsfile)
+    subprocess.run("python3 ../Python/bin/xmltompc80col.py "+xmlfile+" "+obsfile,shell=True)
+    assert(os.path.exists(obsfile) and (os.stat(obsfile).st_size != 0 and os.stat(obsfile).st_size > 1190))

--- a/new_tests/test_xmltompc80col.py
+++ b/new_tests/test_xmltompc80col.py
@@ -13,5 +13,4 @@ def test_trksub_submission():
     if os.path.exists(outfile):
         os.remove(outfile)
     subprocess.run("python3 ../Python/bin/xmltompc80col.py "+infile+" "+outfile, shell=True)
-    assert(os.path.exists(outfile) and os.stat(outfile).st_size != 0)
-    print("****** Test 1 should pass *******")
+    assert(os.path.exists(outfile) and os.stat(outfile).st_size != 0) 

--- a/xml/adesmaster.xml
+++ b/xml/adesmaster.xml
@@ -1748,7 +1748,7 @@ PSVObservationFields doc
    <psv tagtype="occultation" name="prog"      width="2"  justification="R" dpos="0"/>
    <psv tagtype="occultation" name="obsTime"   width="23" justification="L" dpos="0"/>
    <psv tagtype="occultation" name="obsCenter" width="8"  justification="L" dpos="0"/>
-   <psv tagtype="occultatoin" name="raStar"    width="13" justification="D" dpos="4"/>
+   <psv tagtype="occultation" name="raStar"    width="13" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="decStar"   width="12" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="deltaRA"   width="12" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="deltaDec"  width="13" justification="D" dpos="4"/>

--- a/xml/adesmaster.xml
+++ b/xml/adesmaster.xml
@@ -754,7 +754,7 @@ decimal types must be in a range
    <doc> PosDecimalType with no more that 6 characters</doc>
 </simpletype>
 
-<simpletype name="PosDecimalTypeW6">
+<simpletype name="PosDecimalTypeW7">
    <restriction base="PosDecimalType">
       <restrict name="xsd:pattern" value="[0123456789\.]{1,7}"/>
    </restriction>

--- a/xml/adesmaster.xml
+++ b/xml/adesmaster.xml
@@ -1693,8 +1693,8 @@ PSVObservationFields doc
    <psv tagtype="optical" name="obsTime"   width="23" justification="L" dpos="0"/>
    <psv tagtype="optical" name="ra"        width="11" justification="D" dpos="4"/>
    <psv tagtype="optical" name="dec"       width="11" justification="D" dpos="4"/>
-   <psv tagtype="optical" name="rmsRA"     width="5"  justification="D" dpos="2"/>
-   <psv tagtype="optical" name="rmsDec"    width="6"  justification="D" dpos="2"/>
+   <psv tagtype="optical" name="rmsRA"     width="7"  justification="D" dpos="2"/>
+   <psv tagtype="optical" name="rmsDec"    width="7"  justification="D" dpos="2"/>
    <psv tagtype="optical" name="rmsCorr"   width="7"  justification="D" dpos="3"/>
    <psv tagtype="optical" name="astCat"    width="3"  justification="R" dpos="0"/>
    <psv tagtype="optical" name="mag"       width="5"  justification="D" dpos="3"/>
@@ -1719,8 +1719,8 @@ PSVObservationFields doc
    <psv tagtype="offset" name="obsCenter" width="8"  justification="L" dpos="0"/>
    <psv tagtype="offset" name="deltaRA"   width="11" justification="D" dpos="4"/>
    <psv tagtype="offset" name="deltaDec"  width="11" justification="D" dpos="4"/>
-   <psv tagtype="offset" name="rmsRA"     width="5"  justification="D" dpos="2"/>
-   <psv tagtype="offset" name="rmsDec"    width="6"  justification="D" dpos="2"/>
+   <psv tagtype="offset" name="rmsRA"     width="7"  justification="D" dpos="2"/>
+   <psv tagtype="offset" name="rmsDec"    width="7"  justification="D" dpos="2"/>
    <psv tagtype="offset" name="dist"      width="5"  justification="D" dpos="2"/>
    <psv tagtype="offset" name="pa"        width="6"  justification="D" dpos="2"/>
    <psv tagtype="offset" name="rmsdist"   width="7"  justification="D" dpos="3"/>

--- a/xml/adesmaster.xml
+++ b/xml/adesmaster.xml
@@ -1397,6 +1397,7 @@ decimal types must be in a range
    <doc>Optical Occultation Observation with deltaRA, deltaDec, raStar and decStar</doc>
    <sequence>
       <group   ref="OpticalID"   />
+      <element ref="mode"        />
       <element ref="stn"         />
       <group   ref="Location"    use="optional"/>
       <element ref="prog"        use="NoSubmit"/>

--- a/xml/adesmaster.xml
+++ b/xml/adesmaster.xml
@@ -1559,8 +1559,8 @@ decimal types must be in a range
    <element name="raStar"     type="RAType"             doc="J2000.0 RA in decimal degrees of the occulted star"/>
    <element name="decStar"    type="DeclinationType"    doc="J2000.0 DEC in decimal degrees of the occulted star"/>
    <element name="obsCenter"  type="ObsCenterType"      doc="Center of offset observation may be planet or other body with PermID or ProvID"/>
-   <element name="deltaRA"    type="DecimalTypeW10"     doc="Measured $\Delta(\mathrm{RA}\cos\mathrm{ DEC})$ in arcseconds.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in rectangular coordinates, J2000.0 frame."/>
-   <element name="deltaDec"   type="DecimalTypeW10"     doc="Measured  $\Delta$DEC in  arcseconds.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in rectangular coordinates, J2000.0 frame"/>
+   <element name="deltaRA"    type="RAType"             doc="Measured $\Delta(\mathrm{RA}\cos\mathrm{ DEC})$ in arcseconds.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in rectangular coordinates, J2000.0 frame."/>
+   <element name="deltaDec"   type="DeclinationType"    doc="Measured  $\Delta$DEC in  arcseconds.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in rectangular coordinates, J2000.0 frame"/>
    <element name="dist"       type="PosDecimalTypeW10"  doc="Measured distance in arcseconds.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in polar coordinates."/>
    <element name="pa"         type="RAType"             doc="Measured position angle in degrees.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in polar coordinates."/>
    <element name="rmsRA"      type="PosDecimalTypeW7"   doc="Random component of the $\mathrm{RA}\cos\mathrm{DEC}$ $1\sigma$ uncertainty in arcseconds as estimated by the observer as part of the image processing and astrometric reduction."/>
@@ -1692,8 +1692,8 @@ PSVObservationFields doc
    <psv tagtype="optical" name="stn"       width="4"  justification="L" dpos="0"/>
    <psv tagtype="optical" name="prog"      width="2"  justification="R" dpos="0"/>
    <psv tagtype="optical" name="obsTime"   width="23" justification="L" dpos="0"/>
-   <psv tagtype="optical" name="ra"        width="11" justification="D" dpos="4"/>
-   <psv tagtype="optical" name="dec"       width="11" justification="D" dpos="4"/>
+   <psv tagtype="optical" name="ra"        width="12" justification="D" dpos="4"/>
+   <psv tagtype="optical" name="dec"       width="12" justification="D" dpos="4"/>
    <psv tagtype="optical" name="rmsRA"     width="7"  justification="D" dpos="2"/>
    <psv tagtype="optical" name="rmsDec"    width="7"  justification="D" dpos="2"/>
    <psv tagtype="optical" name="rmsCorr"   width="7"  justification="D" dpos="3"/>
@@ -1718,8 +1718,8 @@ PSVObservationFields doc
    <psv tagtype="offset" name="prog"      width="2"  justification="R" dpos="0"/>
    <psv tagtype="offset" name="obsTime"   width="23" justification="L" dpos="0"/>
    <psv tagtype="offset" name="obsCenter" width="8"  justification="L" dpos="0"/>
-   <psv tagtype="offset" name="deltaRA"   width="11" justification="D" dpos="4"/>
-   <psv tagtype="offset" name="deltaDec"  width="11" justification="D" dpos="4"/>
+   <psv tagtype="offset" name="deltaRA"   width="12" justification="D" dpos="4"/>
+   <psv tagtype="offset" name="deltaDec"  width="12" justification="D" dpos="4"/>
    <psv tagtype="offset" name="rmsRA"     width="7"  justification="D" dpos="2"/>
    <psv tagtype="offset" name="rmsDec"    width="7"  justification="D" dpos="2"/>
    <psv tagtype="offset" name="dist"      width="5"  justification="D" dpos="2"/>
@@ -1748,10 +1748,10 @@ PSVObservationFields doc
    <psv tagtype="occultation" name="prog"      width="2"  justification="R" dpos="0"/>
    <psv tagtype="occultation" name="obsTime"   width="23" justification="L" dpos="0"/>
    <psv tagtype="occultation" name="obsCenter" width="8"  justification="L" dpos="0"/>
-   <psv tagtype="occultatoin" name="raStar"    width="11" justification="D" dpos="4"/>
-   <psv tagtype="occultation" name="decStar"   width="11" justification="D" dpos="4"/>
-   <psv tagtype="occultation" name="deltaRA"   width="11" justification="D" dpos="4"/>
-   <psv tagtype="occultation" name="deltaDec"  width="11" justification="D" dpos="4"/>
+   <psv tagtype="occultatoin" name="raStar"    width="13" justification="D" dpos="4"/>
+   <psv tagtype="occultation" name="decStar"   width="12" justification="D" dpos="4"/>
+   <psv tagtype="occultation" name="deltaRA"   width="12" justification="D" dpos="4"/>
+   <psv tagtype="occultation" name="deltaDec"  width="13" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="rmsRA"     width="7"  justification="D" dpos="3"/>
    <psv tagtype="occultation" name="rmsDec"    width="7"  justification="D" dpos="3"/>
    <psv tagtype="occultation" name="dist"      width="11" justification="D" dpos="4"/>

--- a/xml/adesmaster.xml
+++ b/xml/adesmaster.xml
@@ -595,7 +595,7 @@ decimal types must be in a range
   <restriction base="xsd:decimal">
     <restrict name="xsd:minInclusive" value="-90.0"/>
     <restrict name="xsd:maxInclusive" value="90.0"/>
-    <restrict name="xsd:pattern" value="[+\-]?([1-9]?[0-9])?(\.[0123456789]{0,8})?"/>
+    <restrict name="xsd:pattern" value="[+\-]?([1-9]?[0-9])?(\.[0123456789]{0,9})?"/>
   </restriction>
   <doc> $\mathrm{DEC}$ in degrees in range [-90.0, 90.0] with no more that 8 characters after the decimal</doc>
 </simpletype>
@@ -754,6 +754,13 @@ decimal types must be in a range
    <doc> PosDecimalType with no more that 6 characters</doc>
 </simpletype>
 
+<simpletype name="PosDecimalTypeW6">
+   <restriction base="PosDecimalType">
+      <restrict name="xsd:pattern" value="[0123456789\.]{1,7}"/>
+   </restriction>
+   <doc> PosDecimalType with no more that 7 characters</doc>
+</simpletype>
+
 <simpletype name="PosDecimalTypeW8">
    <restriction base="PosDecimalType">
       <restrict name="xsd:pattern" value="[0123456789\.]{1,8}"/>
@@ -859,7 +866,7 @@ decimal types must be in a range
   <restriction base="xsd:decimal">
     <restrict name="xsd:minInclusive" value="0.0"/>
     <restrict name="xsd:maxExclusive" value="360.0"/>
-    <restrict name="xsd:pattern" value="([1-3][0-9]{2}|[1-9]?[0-9])?(\.[0-9]{0,8})?"/>
+    <restrict name="xsd:pattern" value="([1-3][0-9]{2}|[1-9]?[0-9])?(\.[0-9]{0,9})?"/>
   </restriction>
   <doc> Unsigned RA in degrees limited to [0.0, 360.0) with no more that 8 characters after the decimal</doc>
 </simpletype>
@@ -1555,8 +1562,8 @@ decimal types must be in a range
    <element name="deltaDec"   type="DecimalTypeW10"     doc="Measured  $\Delta$DEC in  arcseconds.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in rectangular coordinates, J2000.0 frame"/>
    <element name="dist"       type="PosDecimalTypeW10"  doc="Measured distance in arcseconds.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in polar coordinates."/>
    <element name="pa"         type="RAType"             doc="Measured position angle in degrees.  For offset measurements of a satellite with respect to its primary, or for occultation observations with respect to the star in polar coordinates."/>
-   <element name="rmsRA"      type="PosDecimalTypeW6"   doc="Random component of the $\mathrm{RA}\cos\mathrm{DEC}$ $1\sigma$ uncertainty in arcseconds as estimated by the observer as part of the image processing and astrometric reduction."/>
-   <element name="rmsDec"     type="PosDecimalTypeW6"   doc="Random component of the DEC $1\sigma$ uncertainty in arcseconds as estimated by the observer as part of the image processing and astrometric reduction."/>
+   <element name="rmsRA"      type="PosDecimalTypeW7"   doc="Random component of the $\mathrm{RA}\cos\mathrm{DEC}$ $1\sigma$ uncertainty in arcseconds as estimated by the observer as part of the image processing and astrometric reduction."/>
+   <element name="rmsDec"     type="PosDecimalTypeW7"   doc="Random component of the DEC $1\sigma$ uncertainty in arcseconds as estimated by the observer as part of the image processing and astrometric reduction."/>
    <element name="rmsDist"    type="PosDecimalTypeW6"   doc="Random component of the distance $1\sigma$ uncertainty in arcseconds as estimated by the observer as part of the image processing and astrometric reduction."/>
    <element name="rmsPA"      type="PosDecimalTypeW6"   doc="Random component of the polar angle $1\sigma$ uncertainty in degrees  as estimated by the observer as part of the image processing and astrometric reduction."/>
    <element name="rmsCorr"    type="CorrDecimalType"    doc="Correlation between RA and DEC or dist and PA that may result from the astrometric reduction.  This is derived from the $\mathrm{RA}$-$\mathrm{DEC}$ or $\mathrm{dist}$-$\mathrm{PA}$ covariance matrix, where the off-diagonal term is $\mathrm{rmsCorr} * \mathrm{rmsRA} * \mathrm{rmsDec}$ or $\mathrm{rmsCorr} * \mathrm{rmsDist} * \mathrm{rmsPA}$."/>
@@ -1744,8 +1751,8 @@ PSVObservationFields doc
    <psv tagtype="occultation" name="decStar"   width="11" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="deltaRA"   width="11" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="deltaDec"  width="11" justification="D" dpos="4"/>
-   <psv tagtype="occultation" name="rmsRA"     width="6"  justification="D" dpos="3"/>
-   <psv tagtype="occultation" name="rmsDec"    width="6"  justification="D" dpos="3"/>
+   <psv tagtype="occultation" name="rmsRA"     width="7"  justification="D" dpos="3"/>
+   <psv tagtype="occultation" name="rmsDec"    width="7"  justification="D" dpos="3"/>
    <psv tagtype="occultation" name="dist"      width="11" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="pa"        width="11" justification="D" dpos="4"/>
    <psv tagtype="occultation" name="rmsdist"   width="6"  justification="D" dpos="3"/>

--- a/xsd/general.xsd
+++ b/xsd/general.xsd
@@ -163,7 +163,7 @@
       <xsd:pattern value="[0123456789\.]{1,6}"/>
     </xsd:restriction>
   </xsd:simpleType>
-  <xsd:simpleType name="PosDecimalTypeW6">
+  <xsd:simpleType name="PosDecimalTypeW7">
     <xsd:restriction base="PosDecimalType">
       <xsd:pattern value="[0123456789\.]{1,7}"/>
     </xsd:restriction>
@@ -590,6 +590,7 @@
   <xsd:complexType name="OccultationType">
     <xsd:sequence>
       <xsd:group ref="OpticalID"/>
+      <xsd:element ref="mode"/>
       <xsd:element ref="stn"/>
       <xsd:group ref="Location" minOccurs="0"/>
       <xsd:element ref="prog" minOccurs="0"/>

--- a/xsd/general.xsd
+++ b/xsd/general.xsd
@@ -52,7 +52,7 @@
     <xsd:restriction base="xsd:decimal">
       <xsd:minInclusive value="-90.0"/>
       <xsd:maxInclusive value="90.0"/>
-      <xsd:pattern value="[+\-]?([1-9]?[0-9])?(\.[0123456789]{0,8})?"/>
+      <xsd:pattern value="[+\-]?([1-9]?[0-9])?(\.[0123456789]{0,9})?"/>
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="DeprecatedType">
@@ -163,6 +163,11 @@
       <xsd:pattern value="[0123456789\.]{1,6}"/>
     </xsd:restriction>
   </xsd:simpleType>
+  <xsd:simpleType name="PosDecimalTypeW6">
+    <xsd:restriction base="PosDecimalType">
+      <xsd:pattern value="[0123456789\.]{1,7}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
   <xsd:simpleType name="PosDecimalTypeW8">
     <xsd:restriction base="PosDecimalType">
       <xsd:pattern value="[0123456789\.]{1,8}"/>
@@ -217,7 +222,7 @@
     <xsd:restriction base="xsd:decimal">
       <xsd:minInclusive value="0.0"/>
       <xsd:maxExclusive value="360.0"/>
-      <xsd:pattern value="([1-3][0-9]{2}|[1-9]?[0-9])?(\.[0-9]{0,8})?"/>
+      <xsd:pattern value="([1-3][0-9]{2}|[1-9]?[0-9])?(\.[0-9]{0,9})?"/>
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="RefType">
@@ -717,8 +722,8 @@
   <xsd:element name="deltaDec" type="DecimalTypeW10"/>
   <xsd:element name="dist" type="PosDecimalTypeW10"/>
   <xsd:element name="pa" type="RAType"/>
-  <xsd:element name="rmsRA" type="PosDecimalTypeW6"/>
-  <xsd:element name="rmsDec" type="PosDecimalTypeW6"/>
+  <xsd:element name="rmsRA" type="PosDecimalTypeW7"/>
+  <xsd:element name="rmsDec" type="PosDecimalTypeW7"/>
   <xsd:element name="rmsDist" type="PosDecimalTypeW6"/>
   <xsd:element name="rmsPA" type="PosDecimalTypeW6"/>
   <xsd:element name="rmsCorr" type="CorrDecimalType"/>

--- a/xsd/general.xsd
+++ b/xsd/general.xsd
@@ -719,8 +719,8 @@
   <xsd:element name="raStar" type="RAType"/>
   <xsd:element name="decStar" type="DeclinationType"/>
   <xsd:element name="obsCenter" type="ObsCenterType"/>
-  <xsd:element name="deltaRA" type="DecimalTypeW10"/>
-  <xsd:element name="deltaDec" type="DecimalTypeW10"/>
+  <xsd:element name="deltaRA" type="RAType"/>
+  <xsd:element name="deltaDec" type="DeclinationType"/>
   <xsd:element name="dist" type="PosDecimalTypeW10"/>
   <xsd:element name="pa" type="RAType"/>
   <xsd:element name="rmsRA" type="PosDecimalTypeW7"/>

--- a/xsd/submit.xsd
+++ b/xsd/submit.xsd
@@ -680,8 +680,8 @@
   <xsd:element name="raStar" type="RAType"/>
   <xsd:element name="decStar" type="DeclinationType"/>
   <xsd:element name="obsCenter" type="ObsCenterType"/>
-  <xsd:element name="deltaRA" type="DecimalTypeW10"/>
-  <xsd:element name="deltaDec" type="DecimalTypeW10"/>
+  <xsd:element name="deltaRA" type="RAType"/>
+  <xsd:element name="deltaDec" type="DeclinationType"/>
   <xsd:element name="dist" type="PosDecimalTypeW10"/>
   <xsd:element name="pa" type="RAType"/>
   <xsd:element name="rmsRA" type="PosDecimalTypeW7"/>

--- a/xsd/submit.xsd
+++ b/xsd/submit.xsd
@@ -52,7 +52,7 @@
     <xsd:restriction base="xsd:decimal">
       <xsd:minInclusive value="-90.0"/>
       <xsd:maxInclusive value="90.0"/>
-      <xsd:pattern value="[+\-]?([1-9]?[0-9])?(\.[0123456789]{0,8})?"/>
+      <xsd:pattern value="[+\-]?([1-9]?[0-9])?(\.[0123456789]{0,9})?"/>
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="DeprecatedType">
@@ -163,6 +163,11 @@
       <xsd:pattern value="[0123456789\.]{1,6}"/>
     </xsd:restriction>
   </xsd:simpleType>
+  <xsd:simpleType name="PosDecimalTypeW6">
+    <xsd:restriction base="PosDecimalType">
+      <xsd:pattern value="[0123456789\.]{1,7}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
   <xsd:simpleType name="PosDecimalTypeW8">
     <xsd:restriction base="PosDecimalType">
       <xsd:pattern value="[0123456789\.]{1,8}"/>
@@ -217,7 +222,7 @@
     <xsd:restriction base="xsd:decimal">
       <xsd:minInclusive value="0.0"/>
       <xsd:maxExclusive value="360.0"/>
-      <xsd:pattern value="([1-3][0-9]{2}|[1-9]?[0-9])?(\.[0-9]{0,8})?"/>
+      <xsd:pattern value="([1-3][0-9]{2}|[1-9]?[0-9])?(\.[0-9]{0,9})?"/>
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="RefType">
@@ -678,8 +683,8 @@
   <xsd:element name="deltaDec" type="DecimalTypeW10"/>
   <xsd:element name="dist" type="PosDecimalTypeW10"/>
   <xsd:element name="pa" type="RAType"/>
-  <xsd:element name="rmsRA" type="PosDecimalTypeW6"/>
-  <xsd:element name="rmsDec" type="PosDecimalTypeW6"/>
+  <xsd:element name="rmsRA" type="PosDecimalTypeW7"/>
+  <xsd:element name="rmsDec" type="PosDecimalTypeW7"/>
   <xsd:element name="rmsDist" type="PosDecimalTypeW6"/>
   <xsd:element name="rmsPA" type="PosDecimalTypeW6"/>
   <xsd:element name="rmsCorr" type="CorrDecimalType"/>

--- a/xsd/submit.xsd
+++ b/xsd/submit.xsd
@@ -163,7 +163,7 @@
       <xsd:pattern value="[0123456789\.]{1,6}"/>
     </xsd:restriction>
   </xsd:simpleType>
-  <xsd:simpleType name="PosDecimalTypeW6">
+  <xsd:simpleType name="PosDecimalTypeW7">
     <xsd:restriction base="PosDecimalType">
       <xsd:pattern value="[0123456789\.]{1,7}"/>
     </xsd:restriction>
@@ -569,6 +569,7 @@
   <xsd:complexType name="OccultationType">
     <xsd:sequence>
       <xsd:group ref="OpticalID"/>
+      <xsd:element ref="mode"/>
       <xsd:element ref="stn"/>
       <xsd:group ref="Location" minOccurs="0"/>
       <xsd:element ref="obsTime"/>


### PR DESCRIPTION
The ADES repository had some problems with the new occultation format. 

- I have changed xml/adesmaster.xml to include 'mode' for occultations;
- I have changed xml/adesmaster.xml to include one more digit for raStar and decStar (from 8 to 9) for the occultations and one more digit for rmsRA and rmsDec (from 6 to 7) for the Gaia mission. To change the rmsRA and rmsDec I have created a new type field (W7)
- I have recreated the two xsd files in the xsd folder
- I have changed Python/bin/xmltompc80col.py to convert occultations as well (obscode 275 has been tested, but we don't have any data for 244)
- I added tests for occultations (conversion from psv to xml and from xml to obs80) and I added the corresponding files in the new_tests directory

@stevechesley I wasn't able to recreate the pdfs once I have changed the master xml. How do I do that? 