### PR TITLE
Validation of XML Declaration / Preamble

### DIFF
--- a/Python/bin/packUtil.py
+++ b/Python/bin/packUtil.py
@@ -465,11 +465,11 @@ minorplanetPackedIDRegex = re.compile('^(?: {5}|([0-9A-Za-z])(\d{4})|(~[0-9A-Za-
 #
 # Add "I" for interstellar objects
 #
-cometPackedIDRegex = re.compile('^(?: {4}|(\d{4}))([APCDXI])'
-                                  + '(?:' + '([0-9A-Za-z])(\d{2})([A-HJ-Y])([a-zA-Z0-9])(\d)(?:0|([A-Z])|([a-z]))' + '|'
-                                          + '     ([a-z ])([a-z])'  + '|'
-                                          + ' *$'
-                                  + ')$')
+cometPackedIDRegex = re.compile(r'^(?: {4}|(\d{4}))([APCDXI])'
+                                  + r'(?:' + r'([0-9A-Za-z])(\d{2})([A-HJ-Y])([a-zA-Z0-9])(\d)(?:0|([A-Z])|([a-z]))' + r'|'
+                                          + r'     ([a-z ])([a-z])'  + '|'
+                                          + r' *$'
+                                  + r')$')
 
 #
 # Satellite groups:

--- a/Python/bin/sexVals.py
+++ b/Python/bin/sexVals.py
@@ -58,11 +58,11 @@ def valueError(s, line, c1, c2, value=None):
 #
 # Sexagesimal Parsing
 #
-_checkNormal = re.compile('^(\d\d) (\d\d) (\d\d\.(\d*)) *$')
-_checkIntegerSeconds = re.compile('^(\d\d) (\d\d) (\d\d) *$')
-_checkMinutesHundredths = re.compile('^(\d\d) (\d\d\.\d\d) *$')
-_checkMinutesTenths = re.compile('^(\d\d) (\d\d\.\d) *$')
-_checkIntegerMinutes = re.compile('^(\d\d) (\d\d) *$')
+_checkNormal = re.compile(r'^(\d\d) (\d\d) (\d\d\.(\d*)) *$')
+_checkIntegerSeconds = re.compile(r'^(\d\d) (\d\d) (\d\d) *$')
+_checkMinutesHundredths = re.compile(r'^(\d\d) (\d\d\.\d\d) *$')
+_checkMinutesTenths = re.compile(r'^(\d\d) (\d\d\.\d) *$')
+_checkIntegerMinutes = re.compile(r'^(\d\d) (\d\d) *$')
 
 _countNormal = 0
 _countIntegerSeconds = 0
@@ -170,7 +170,7 @@ def checkSexagesimal(line):
 
       
 
-_checkDate = re.compile('^((16|17|18|19|[2-9]\d)\d\d) (0[1-9]|10|11|12) ((0[1-9]|[12]\d|30|31)\.(\d+)) *$')
+_checkDate = re.compile(r'^((16|17|18|19|[2-9]\d)\d\d) (0[1-9]|10|11|12) ((0[1-9]|[12]\d|30|31)\.(\d+)) *$')
 #testdate("1800 00 01.333  ")  # bad month
 #testdate("1800 01 00.333  ")  # bad day
 #testdate("1800 01 01    ")

--- a/Python/bin/valall.py
+++ b/Python/bin/valall.py
@@ -19,6 +19,7 @@ import sys
 import argparse
 
 import adesutility
+from valutility import validate_xslts, validate_xml_declaration
 
 #
 # This script validates an xml file against six different
@@ -33,8 +34,6 @@ import adesutility
 #
 
 def valall(xmlfile):
-  masterfile = adesutility.adesmaster
-
   #
   # Six xsd schemas are built, in pairs designed to be favored
   # for machine reading and human reading.  Both items in a pair
@@ -46,51 +45,17 @@ def valall(xmlfile):
   #
   #
   schemaxslts = adesutility.schemaxslts
-
-
-  results = {}
-
   #
-  # read in master file 
-  #
-  xml_tree = adesutility.readXML(masterfile)
-
-  #
-  # read in file to be validataed from sys.argv[1]
+  # read in file to be validataed
   #
   candidate = adesutility.readXML(xmlfile)
-
   #
   # validate against all schemaxslt files
   # 
-  for schemaName in schemaxslts:
-    xslt_tree = adesutility.readXML(schemaxslts[schemaName])
-    schema = adesutility.XMLtoSchemaViaXSLT(xml_tree, xslt_tree)
-    #
-    # check the input xml against the generated schema.
-    #
-    try:
-      schema.assertValid(candidate)
-      results[schemaName] = None
-    except:  
-      results[schemaName] = traceback.format_exc()
-
-  #
-  # now print the results, and the reason for failure if the
-  # validation failed.  
-  #
-  out = open("valall.file",'w')
-  for result in sorted(results):
-    r = results[result]
-    if r:
-      print (result, "has failed:")
-      out.write(result+" has failed: "+r+"\n")
-      print (r)
-    else:
-      print (result, "is OK")
-      out.write(result+" is OK\n")
-  out.close()
-      
+  with open("valall.file", "w") as out:
+    validate_xml_declaration(xmlfile, out)
+    validate_xslts(adesutility.schemaxslts, candidate, out)
+        
 # --------------------------------------------------------------
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/Python/bin/valgeneral.py
+++ b/Python/bin/valgeneral.py
@@ -19,6 +19,7 @@ import sys
 import argparse
 
 import adesutility
+from valutility import validate_xslt, validate_xml_declaration
 
 #
 # This script validates an xml file against six different
@@ -44,55 +45,16 @@ def valgeneral(xmlfile):
   #    generalxsd.xslt      generalhumanxsd.xslt   -- both
   #
   #
-  schemaxslts = { 'general': adesutility.schemaxslts['general'] }
-  
-  
-  results = {}
-  
   #
-  # read in master file 
-  #
-  xml_tree = adesutility.readXML(masterfile)
-  
-  #
-  # read in file to be validataed from sys.argv[1]
+  # read in file to be validataed
   #
   candidate = adesutility.readXML(xmlfile)
-  
   #
   # validate against general schemaxslt files
   # 
-  for schemaName in schemaxslts:
-    xslt_tree = adesutility.readXML(schemaxslts[schemaName])
-    schema = adesutility.XMLtoSchemaViaXSLT(xml_tree, xslt_tree)
-    #
-    # check the input xml against the generated schema.
-    #
-    try:
-      schema.assertValid(candidate)
-      results[schemaName] = None
-    except:  
-      results[schemaName] = traceback.format_exc()
-  
-  #
-  # now print the results, and the reason for failure if the
-  # validation failed.  
-  #
-  #Also write on a file
-  
-  out = open("valgeneral.file",'w')
-
-  for result in sorted(results):
-    r = results[result]
-    if r:
-      print (result, "has failed:")
-      out.write(result+"has failed: "+r)
-      print (r)
-    else:
-      print (result, "is OK")
-      out.write(result+" is OK")
-  out.close()
-
+  with open("valgeneral.file", "w") as out:
+    validate_xml_declaration(xmlfile, out)
+    validate_xslt("general", adesutility.schemaxslts['general'], candidate, out)
   
   
 # ------------------------------------------------------------

--- a/Python/bin/validate.py
+++ b/Python/bin/validate.py
@@ -26,6 +26,9 @@ from xmlutility import XMLtoSchema
 import sys
 import argparse
 
+import adesutility
+from valutility import validate_schema, validate_xml_declaration
+
 #
 # Read in the schema
 #
@@ -35,39 +38,18 @@ import argparse
 def validate(schemafile, xmlfile):
     results = {}
 
-    schemaxml = readXML(schemafile)
-    schema  = XMLtoSchema(schemaxml)
-
     #
     # Read in the xml file
     #
     #candidate = lxml.etree.parse(sys.argv[2])
     candidate = readXML(xmlfile)
+    
+    schemaxml = readXML(schemafile)
+    schema  = XMLtoSchema(schemaxml)
 
-    #
-    # Check for validity -- prints errors on stdout if any are found
-    #
-    try:
-        schema.assertValid(candidate)
-        results[schema] = None
-    except:  
-        results[schema] = traceback.format_exc()
-      
-    #
-    # now print the results, and the reason for failure if the
-    # validation failed.  
-    #
-    out = open("validate.file",'w')
-    for result in sorted(results):
-        r = results[result]
-        if r:
-            print (result, "has failed:")
-            out.write(str(result)+" has failed: \n")
-            print (r)
-        else:
-            print (result, "is OK")
-            out.write(str(result)+" is OK\n")
-    out.close()
+    with open("validate.file", "w") as out:
+        validate_xml_declaration(xmlfile, out)
+        validate_schema(schema, schema, candidate, out)
     
 # -------------------------------------------------------------------
 if __name__ == '__main__':

--- a/Python/bin/validate.py
+++ b/Python/bin/validate.py
@@ -49,7 +49,7 @@ def validate(schemafile, xmlfile):
 
     with open("validate.file", "w") as out:
         validate_xml_declaration(xmlfile, out)
-        validate_schema(schema, schema, candidate, out)
+        validate_schema(schemafile, schema, candidate, out)
     
 # -------------------------------------------------------------------
 if __name__ == '__main__':

--- a/Python/bin/valsubmit.py
+++ b/Python/bin/valsubmit.py
@@ -19,6 +19,7 @@ import sys
 import argparse
 
 import adesutility
+from valutility import validate_xslt, validate_xml_declaration
 
 #
 # This script validates an xml file against six different
@@ -33,8 +34,6 @@ import adesutility
 #
 
 def valsubmit(xmlfile):
-  masterfile = adesutility.adesmaster
-
   #
   # Six xsd schemas are built, in pairs designed to be favored
   # for machine reading and human reading.  Both items in a pair
@@ -45,52 +44,17 @@ def valsubmit(xmlfile):
   #    generalxsd.xslt      generalhumanxsd.xslt   -- both
   #
   #
-  schemaxslts = { 'submit': adesutility.schemaxslts['submit'] }
-
-
-  results = {}
-
   #
-  # read in master file 
-  #
-  xml_tree = adesutility.readXML(masterfile)
-
-  #
-  # read in file to be validataed from sys.argv[1]
+  # read in file to be validataed
   #
   candidate = adesutility.readXML(xmlfile)
-
   #
   # validate against submit schemaxslt files
   # 
-  for schemaName in schemaxslts:
-    xslt_tree = adesutility.readXML(schemaxslts[schemaName])
-    schema = adesutility.XMLtoSchemaViaXSLT(xml_tree, xslt_tree)
-    #
-    # check the input xml against the generated schema.
-    #
-    try:
-      schema.assertValid(candidate)
-      results[schemaName] = None
-    except:  
-      results[schemaName] = traceback.format_exc()
-
-  #
-  # now print the results, and the reason for failure if the
-  # validation failed.  
-  #
-  out = open("valsubmit.file",'w')
+  with open("valsubmit.file",'w') as out:
+    validate_xml_declaration(xmlfile, out)
+    validate_xslt("submit", adesutility.schemaxslts['submit'], candidate, out)
   
-  for result in sorted(results):
-    r = results[result]
-    if r:
-      print (result, "has failed:")
-      out.write(str(result)+" has failed\n")
-      print (r)
-    else:
-      print (result, "is OK")
-      out.write(str(result)+" is OK")
-
 # --------------------------------------------------------
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/Python/bin/valutility.py
+++ b/Python/bin/valutility.py
@@ -50,7 +50,7 @@ def validate_xslt(schema_name, schemaxslt, candidate, out):
 
 def validate_xslts(schemaxslts, candidate, out):
     results = {}
-    for schema_name in sorted(schemaxslts):
+    for schema_name in schemaxslts:
         results[schema_name] = validate_xslt(schema_name, schemaxslts[schema_name], candidate, out)
     return results
 

--- a/Python/bin/valutility.py
+++ b/Python/bin/valutility.py
@@ -1,0 +1,68 @@
+# __future__ imports for Python 3 compliance in Python 2
+# 
+from __future__ import absolute_import, division, print_function
+from __future__ import unicode_literals
+
+import traceback
+import sys
+import argparse
+import re
+
+import adesutility
+
+
+def validate_schema(schema_name, schema, candidate, out):
+    #
+    # Check for validity -- prints errors on stdout if any are found
+    #
+    try:
+        schema.assertValid(candidate)
+        result = None
+    except:  
+        result = traceback.format_exc()
+
+    #
+    # now print the results, and the reason for failure if the
+    # validation failed.  
+    #
+    if result:
+        print (schema_name, "has failed:")
+        out.write(str(schema_name)+" has failed: \n")
+        print (result)
+    else:
+        print (schema_name, "is OK")
+        out.write(str(schema_name)+" is OK\n")
+
+    return result
+
+def validate_xslt(schema_name, schemaxslt, candidate, out):
+    masterfile = adesutility.adesmaster
+
+    #
+    # read in master file 
+    #
+    xml_tree = adesutility.readXML(masterfile)
+
+    xslt_tree = adesutility.readXML(schemaxslt)
+    schema = adesutility.XMLtoSchemaViaXSLT(xml_tree, xslt_tree)
+
+    return validate_schema(schema_name, schema, candidate, out)
+
+def validate_xslts(schemaxslts, candidate, out):
+    results = {}
+    for schema_name in sorted(schemaxslts):
+        results[schema_name] = validate_xslt(schema_name, schemaxslts[schema_name], candidate, out)
+    return results
+
+def validate_xml_declaration(xmlfile, out):
+    valid = False
+    with open(xmlfile, "r") as f:
+        for line in f.readlines():
+            if line.strip() != "":
+                match = re.search(r"^<\?xml.*\?>", line.strip())
+                valid = (match is not None)
+            break
+    
+    if not valid:
+        print("candidate file", xmlfile, "has no XML declaration")
+        print("candidate file", xmlfile, "has no XML declaration", file=out)

--- a/new_tests/test_validation.py
+++ b/new_tests/test_validation.py
@@ -12,6 +12,7 @@ import valgeneral
 import valall
 import validate
 import valsubmit
+import adesutility
 
 
 '''
@@ -48,15 +49,22 @@ def test_valgeneral_routine():
 # valall
 def test_valall():
     xmlfile = "input/obs_v2022.xml"
-    if os.path.exists("validation.file"):
-        os.remove("validation.file")
-    subprocess.run("python3 ../Python/bin/valall.py "+xmlfile+"> validation.file",shell=True)
-    with open("validation.file",'r') as valfile:
-        val = valfile.readlines()[0].replace("\n","")
-        if val == 'general is OK':
-            assert(True)
-        else:
-            assert(False)
+    if os.path.exists("valall.file"):
+        os.remove("valall.file")
+    subprocess.run("python3 ../Python/bin/valall.py "+xmlfile+"> valall.file",shell=True)
+    with open("valall.file",'r') as valfile:
+        lines = [line.strip() for line in valfile.readlines()]
+        assert(all([f"{schema_name} is OK" in lines for schema_name in sorted(adesutility.schemaxslts.keys())]))
+        # for line in valfile.readlines()
+
+        #     if line.strip() in :
+
+        # val = valfile.readlines()[0].replace("\n","")
+
+        # if val == 'general is OK':
+        #     assert(True)
+        # else:
+        #     assert(False)
 
 def test_valall_routine():
     xmlfile = "input/obs_v2022.xml"
@@ -64,11 +72,8 @@ def test_valall_routine():
         os.remove("valall.file")
     valall.valall(xmlfile)
     with open("valall.file",'r') as valfile:
-        val = valfile.readlines()[0].replace("\n","")
-        if val == 'general is OK':
-            assert(True)
-        else:
-            assert(False)
+        lines = [line.strip() for line in valfile.readlines()]
+        assert(all([f"{schema_name} is OK" in lines for schema_name in adesutility.schemaxslts.keys()]))
             
 # ------------------------
 # validate


### PR DESCRIPTION
This PR changes the validation code to detect the presence of `<?xml version='1.0' encoding='UTF-8'?>` as the first line of a candidate XML file.

After looking into it, it doesn't seem there is a way to enforce this in the schema that is used for validation currently. From [what I read](https://stackoverflow.com/questions/1373527/is-it-possible-for-a-xsd-file-to-valide-a-xml-file-by-encoding-type), the schema validates the form of the XML contents while the version and encoding are ways of representing the XML contents in the file. So the XML preamble that declares the version and encoding is out of scope for schema validation.

I then checked if the absence of a declared version and encoding can be detected when the XML file is parsed. When using Python's `lxml.etree.parse` function, the version and encoding are stored in the returned `lxml.etree._ElementTree.docinfo.xml_version` and `lxml.etree._ElementTree.docinfo.encoding` attributes. However, when the XML preamble is not included in an XML file, the `lxml` parser defaults to `xml_version=1.0` and `encoding='UTF-8'` which means this can't be used to detect the presence/absence of the XML preamble in the XML file.

I settled for performing a regular expression match `^<\?xml.*\?>` against the first non-blank line in the XML file: https://github.com/IAU-ADES/ADES-Master/commit/757a0c6712a6ff1fee92292ad9903bf57d212c7e#diff-a4c8786b360a478f5afa1fb5a4f1da23dec09efcfc38833c9437f460851ed499R57-R68 A message will be printed to `stdout` and also to an output file indicating that the candidate file does not have the XML preamble present.

In addition to this, I did some cleanup of the validation code, to remove duplicate code between `valall.py`, `valgeneral.py`, `valsubmit.py`, and `validate.py` since they were all performing similar actions. I also noticed in testing warnings about needing to quote control characters in the regular expression strings used in `packUtils.py` and `sexVals.py`, so I made that change too.