### PR TITLE
fix mpc80coltoxml failing without nosplit

### DIFF
--- a/Python/bin/mpc80coltoxml.py
+++ b/Python/bin/mpc80coltoxml.py
@@ -1038,33 +1038,33 @@ def splitRadar(fname):
       l1 = f.readline()[0:81]  # remove trailing newline and/or cr
       try:
          while (l1):  # emulate do .. while structure
-            (al1, aflag, al2, adoppler, adelay, al3) = parseRadarLine(l1)
-            if aflag != 'R':   # just pass through
+            if headerRegex.match(l1):
                yield l1
-            else:              # need second line
-               l2 = f.readline()[0:81]  # remove trailing newline
-               (bl1, bflag, bl2, bdoppler, bdelay, bl3) = parseRadarLine(l2)
-               if bflag != 'r':
-                  raise RuntimeError("flag must be r not "  +  bflag)
-
-               if (adoppler.strip() and adelay.strip()): # If both are present make two entries
-                  nSplit += 1
-                  splitLines.append (lineNumber)
-                  yield al1 + aflag + al2 + adoppler + 14*' ' + al3
-                  lineNumber += 1
-                  yield bl1 + bflag + bl2 + bdoppler + 14*' ' + bl3
-                  lineNumber -= 1
-                  yield al1 + aflag + al2 + 13*' ' + adelay + al3
-                  lineNumber += 1
-                  yield bl1 + bflag + bl2 + 13*' ' + bdelay + bl3
-               else: # normal case just yield l1 and then l2
+            else:
+               (al1, aflag, al2, adoppler, adelay, al3) = parseRadarLine(l1)
+               if aflag != 'R':   # just pass through
                   yield l1
-                  lineNumber += 1
-                  yield l2
+               else:              # need second line
+                  l2 = f.readline()[0:81]  # remove trailing newline
+                  (bl1, bflag, bl2, bdoppler, bdelay, bl3) = parseRadarLine(l2)
+                  if bflag != 'r':
+                     raise RuntimeError("flag must be r not "  +  bflag)
 
-
-       
-
+                  if (adoppler.strip() and adelay.strip()): # If both are present make two entries
+                     nSplit += 1
+                     splitLines.append (lineNumber)
+                     yield al1 + aflag + al2 + adoppler + 14*' ' + al3
+                     lineNumber += 1
+                     yield bl1 + bflag + bl2 + bdoppler + 14*' ' + bl3
+                     lineNumber -= 1
+                     yield al1 + aflag + al2 + 13*' ' + adelay + al3
+                     lineNumber += 1
+                     yield bl1 + bflag + bl2 + 13*' ' + bdelay + bl3
+                  else: # normal case just yield l1 and then l2
+                     yield l1
+                     lineNumber += 1
+                     yield l2
+               
             lineNumber += 1
             l1 = f.readline()[0:81]
       except Exception as e:

--- a/Python/bin/valutility.py
+++ b/Python/bin/valutility.py
@@ -61,7 +61,7 @@ def validate_xml_declaration(xmlfile, out):
             if line.strip() != "":
                 match = re.search(r"^<\?xml.*\?>", line.strip())
                 valid = (match is not None)
-            break
+                break
     
     if not valid:
         print("candidate file", xmlfile, "has no XML declaration")

--- a/new_tests/test_mpc80coltoxml.py
+++ b/new_tests/test_mpc80coltoxml.py
@@ -50,7 +50,6 @@ def test_mpc80coltoxml_submitted_nosplit_routine():
 
 # ------------------ Testing with the header without --nosplit ------------------    
 #Testing file with the header, but without using --nosplit -- this test does not pass
-@pytest.mark.xfail
 def test_mpc80coltoxml_submitted_split():
     obsfile = "input/85_test.obs"
     xmlfile = "output/85_test_split.xml"
@@ -60,7 +59,6 @@ def test_mpc80coltoxml_submitted_split():
     print('******* Test 3 should fail ********')
     assert(os.path.exists(xmlfile))
     
-@pytest.mark.xfail
 def test_mpc80coltoxml_submitted_split_routine():
     obsfile = "input/85_test.obs"
     xmlfile = "output/85_test_split.xml"


### PR DESCRIPTION
This PR attempts to fix `mpc80coltoxml` failing to convert when not splitting radar lines.

The reason that the `85_test.obs` file was not passing was because it had header information included in it. The issue was that `splitRadar` would call `parseRadar` on the header lines and fail to parse them. I've made a change in `splitRadar` to simply yield the line for parsing if it is a header line. The file then seems to be parsed in the same way that it is parsed when the `--nosplit` argument is used. This issue wasn't present with `--nosplit` because `doNotSplitRadar` simply yielded lines from the file without doing any further parsing.