### PR TITLE
Support stdin/stdout for Python command line conversion tools

### DIFF
--- a/Python/bin/convertutility.py
+++ b/Python/bin/convertutility.py
@@ -1,0 +1,54 @@
+import io
+import builtins
+import tempfile
+import sys
+import argparse
+
+def call_with_files(call, args):
+    with tempfile.NamedTemporaryFile() as tmp_i, tempfile.NamedTemporaryFile() as tmp_o:
+        args_input = getattr(args, "input")
+        if args_input == sys.stdin:
+            i = io.TextIOWrapper(sys.stdin.buffer, encoding=args.input_encoding)
+            with builtins.open(tmp_i.name, "w", encoding=args.input_encoding) as f:
+                f.write(i.read())
+            i = tmp_i.name
+        else:
+            i = args.input
+
+        args_output = getattr(args, "output", None)
+
+        if args_output == sys.stdout:
+            o = tmp_o.name
+        else:
+            o = args_output
+        
+        call(i, o)
+
+        if args_output == sys.stdout:
+            o = io.TextIOWrapper(sys.stdout.buffer, encoding=args.output_encoding)
+            with builtins.open(tmp_o.name, "r", encoding=args.output_encoding) as f:
+                o.write(f.read())
+
+def conversion_parser(parser=None, input_help=None, output_help=None, **kwargs):
+    parser = input_parser(parser, input_help=input_help, **kwargs)
+    parser = output_parser(parser, output_help=output_help, **kwargs)
+    return parser
+
+def input_parser(parser=None, input_help=None, **kwargs):
+    if parser is None:
+        parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter, **kwargs)
+    if input_help is None:
+        input_help = "The input file to convert"
+    
+    parser.add_argument("input", nargs='?', type=str, default=sys.stdin, help=input_help)
+    parser.add_argument("--input-encoding", default="utf-8", help="The text encoding of the input.")
+    return parser
+
+def output_parser(parser=None, output_help=None, **kwargs):
+    if parser is None:
+        parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter, **kwargs)
+    if output_help is None:
+        output_help = "The output file to write conversion to"
+    parser.add_argument("output", nargs='?', type=str, default=sys.stdout, help=output_help)
+    parser.add_argument("--output-encoding", default="utf-8", help="The text encoding of the output")
+    return parser

--- a/Python/bin/convertutility.py
+++ b/Python/bin/convertutility.py
@@ -2,39 +2,109 @@ import io
 import builtins
 import tempfile
 import sys
+import os
 import argparse
 
+"""convertutility.py
+
+The set of utilities in this module allows for generalized construction 
+of argument parsing utilities (argparse.ArgumentParser objects)
+as well as stdin/stdout wrapping for the ADES Python conversion utilities.
+The purpose of these tools is to generalize how the ADES Python conversion utilities 
+define and handle I/O and text encoding when used via the command line.
+"""
+
 def call_with_files(call, args):
+    """Given a callable function and a namespace of its argument, calls the provided function with temporary files/filenames as arguments if stdin/stdout are provided for input/output.
+
+    Args:
+        call (callable): A function to call with signature call(input, output) where input and output are filenames.
+        args (argparse.Namespace): A set of command line arguments parsed with argparse. Required to contain "input" and "input_encoding". Optionally contains "output" and "output_encoding".
+    
+    Raises:
+        ValueError: if the input/output are not stdin/stdout and also not interpretable as a filename
+        AttributeError: if input/input_encoding or output/output_encoding are not available in args when required
+    """
+    def verify_filename(filename):
+        """Verify that a filename is interpretable as a filename
+
+        Args:
+            filename (Any): checks that the filename is None or one of str, bytes, or os.PathLike
+
+        Raises:
+            ValueError: if the filename is not None or one of str, bytes, or os.PathLike
+        """
+        if filename is not None and type(filename) not in [str, bytes, os.PathLike]:
+            raise ValueError(f"{filename} is not a filename")
+
+    # open temporary files
     with tempfile.NamedTemporaryFile() as tmp_i, tempfile.NamedTemporaryFile() as tmp_o:
         args_input = getattr(args, "input")
+        args_input_encoding = getattr(args, "input_encoding")
+        # check if command line input is stdin
         if args_input == sys.stdin:
-            i = io.TextIOWrapper(sys.stdin.buffer, encoding=args.input_encoding)
-            with builtins.open(tmp_i.name, "w", encoding=args.input_encoding) as f:
+            # encode the stdin byte stream using the specified input encoding
+            i = io.TextIOWrapper(sys.stdin.buffer, encoding=args_input_encoding)
+            # write stdin to a temporary file
+            with builtins.open(tmp_i.name, "w", encoding=args_input_encoding) as f:
                 f.write(i.read())
+            # replace function input with the name of the temporary file
             i = tmp_i.name
         else:
-            i = args.input
+            # verify that the input is interpretable as a filename
+            verify_filename(args_input)
+            # use function input as-is
+            i = args_input
 
+        # get optional function output
         args_output = getattr(args, "output", None)
 
+        # check if output is stdout
         if args_output == sys.stdout:
+            # use temporary file name as function output
             o = tmp_o.name
         else:
+            # verify that the output is interpretable as a filename
+            verify_filename(args_output)
+            # use function output as-is
             o = args_output
-        
+
+        # call the function using the newly defined input/output
         call(i, o)
 
+        # check if original output was stdout
         if args_output == sys.stdout:
-            o = io.TextIOWrapper(sys.stdout.buffer, encoding=args.output_encoding)
-            with builtins.open(tmp_o.name, "r", encoding=args.output_encoding) as f:
+            args_output_encoding = getattr(args, "output_encoding")
+            # print the contents of the temporary output file to stdout, using the desired output encoding
+            o = io.TextIOWrapper(sys.stdout.buffer, encoding=args_output_encoding)
+            with builtins.open(tmp_o.name, "r", encoding=args_output_encoding) as f:
                 o.write(f.read())
 
 def conversion_parser(parser=None, input_help=None, output_help=None, **kwargs):
+    """Construct or modify an argparse ArgumentParser object to add an input/ouput and input/output encoding argument
+
+    Args:
+        parser (argparse.ArgumentParser, optional): A parser to add arguments to. If None, constructs a new parser. Defaults to None.
+        input_help (str, optional): The help string for the input argument. Defaults to None.
+        output_help (str, optional): The help string for the output argument. Defaults to None.
+
+    Returns:
+        argparse.ArgumentParser: A parser with input/ouput and input/output encoding arguments included
+    """
     parser = input_parser(parser, input_help=input_help, **kwargs)
     parser = output_parser(parser, output_help=output_help, **kwargs)
     return parser
 
 def input_parser(parser=None, input_help=None, **kwargs):
+    """Construct or modify an argparse ArgumentParser object to add an input/input encoding argument
+
+    Args:
+        parser (argparse.ArgumentParser, optional): A parser to add arguments to. If None, constructs a new parser. Defaults to None.
+        input_help (str, optional): The help string for the input argument. Defaults to None.
+
+    Returns:
+        argparse.ArgumentParser: A parser with input/input encoding arguments included
+    """
     if parser is None:
         parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter, **kwargs)
     if input_help is None:
@@ -45,6 +115,15 @@ def input_parser(parser=None, input_help=None, **kwargs):
     return parser
 
 def output_parser(parser=None, output_help=None, **kwargs):
+    """Construct or modify an argparse ArgumentParser object to add an output/output encoding argument
+
+    Args:
+        parser (argparse.ArgumentParser, optional): A parser to add arguments to. If None, constructs a new parser. Defaults to None.
+        output_help (str, optional): The help string for the output argument. Defaults to None.
+
+    Returns:
+        argparse.ArgumentParser: A parser with output/output encoding arguments included
+    """
     if parser is None:
         parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter, **kwargs)
     if output_help is None:

--- a/Python/bin/jsontoxml.py
+++ b/Python/bin/jsontoxml.py
@@ -12,7 +12,6 @@ import json
 import argparse
 from collections import OrderedDict  # Only necessary for python < 3.7
 import convertutility
-import sys
 
 def jsontoxml(jsonfile , xmlfile , jsonencoding="utf-8", xmlencoding="utf-8"):
     """ """
@@ -21,11 +20,14 @@ def jsontoxml(jsonfile , xmlfile , jsonencoding="utf-8", xmlencoding="utf-8"):
 
 if __name__ == '__main__':
     # read command line arguments
+    # construct argument parser for a conversion tool
     parser = convertutility.conversion_parser(
       description='Convert ADES JSON to XML', 
     )
     args = parser.parse_args()
 
     # call function to read xml into a dict and then write to json
+    # create callable
     call = lambda i, o : jsontoxml(i, o, jsonencoding=args.input_encoding, xmlencoding=args.output_encoding)
+    # call function with filename arguments
     convertutility.call_with_files(call, args)

--- a/Python/bin/jsontoxml.py
+++ b/Python/bin/jsontoxml.py
@@ -11,20 +11,21 @@ import xmltodict
 import json
 import argparse
 from collections import OrderedDict  # Only necessary for python < 3.7
+import convertutility
+import sys
 
-def jsontoxml(jsonfile , xmlfile , jsonencoding="utf-8"):
+def jsontoxml(jsonfile , xmlfile , jsonencoding="utf-8", xmlencoding="utf-8"):
     """ """
-    with open(jsonfile, 'r', encoding=jsonencoding) as jf, open(xmlfile, 'w') as xf:
-        xf.write( xmltodict.unparse( json.load(jf, object_pairs_hook=OrderedDict) , pretty=True) )
+    with open(jsonfile, 'r', encoding=jsonencoding) as jf, open(xmlfile, 'w', encoding=xmlencoding) as xf:
+        xf.write( xmltodict.unparse( json.load(jf, object_pairs_hook=OrderedDict) , pretty=True, encoding=xmlencoding) )
 
 if __name__ == '__main__':
-
     # read command line arguments
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("jsonfile", type=str, help="JSON file to convert to XML")
-    parser.add_argument("xmlfile", type=str, help="Path to write XML data to")
-    parser.add_argument("--jsonencoding", default="utf-8", type=str, help="Text encoding for JSON input")
+    parser = convertutility.conversion_parser(
+      description='Convert ADES JSON to XML', 
+    )
     args = parser.parse_args()
 
     # call function to read xml into a dict and then write to json
-    jsontoxml(args.jsonfile, args.xmlfile, jsonencoding=args.jsonencoding)
+    call = lambda i, o : jsontoxml(i, o, jsonencoding=args.input_encoding, xmlencoding=args.output_encoding)
+    convertutility.call_with_files(call, args)

--- a/Python/bin/mpc80coltoxml.py
+++ b/Python/bin/mpc80coltoxml.py
@@ -20,7 +20,6 @@ import adesutility
 import packUtil
 import sexVals
 import convertutility
-import tempfile
 
 #codeDict = {  # converts code to mode for optical type
 #
@@ -1104,6 +1103,7 @@ def mpc80coltoxml(inmpcfile, outxmlfile, nosplit=False, input_encoding='utf-8', 
 
 #---------------------------------------------------------------------
 if __name__ == '__main__':
+   # construct argument parser for a conversion tool
    parser = convertutility.conversion_parser(
       description='Convert MPC obs80 to ADES XML.', 
    )
@@ -1113,13 +1113,17 @@ if __name__ == '__main__':
    args = parser.parse_args()
 
    try:
+      # check if only doing validation
       if args.val_only:
          if args.input is not sys.stdin and args.output is not sys.stdout:
             raise Exception("Error: cannot request output file for --val-only")
          else:
+            # send output to /dev/null on Unix or null on Window
             args.output = os.devnull
-
+      
+      # create callable
       call = lambda i, o : mpc80coltoxml(i, o, nosplit=args.nosplit, input_encoding=args.input_encoding, output_encoding=args.output_encoding)
+      # call function with filename arguments
       convertutility.call_with_files(call, args)
    except Exception as e:
       print("Error", e)

--- a/Python/bin/mpc80coltoxml.py
+++ b/Python/bin/mpc80coltoxml.py
@@ -738,17 +738,17 @@ def printit(item, lineNumber):
 # convert to XML -- note preamble and postamble since we aren't using yield
 #
 outXMLFile = None
-def convertitPreamble(file, output_encoding='utf-8'):  # set up elementTree
+def convertitPreamble(fname, output_encoding='utf-8'):  # set up elementTree
    global outXMLFile
    global stack
    global allowedElementDict
    global firstElement
    global inObsBlock
    global firstObsBlock
-   if file is None:
+   if fname is None:
        return
    #print ("set up elementTree")
-   outXMLFile = file
+   outXMLFile = fname
 
    (allowedElementDict, requiredElementDict, psvFormatDict)  = adesutility.getAdesTables()
    MPC80OpticalElements = ['permID', 'provID', 'trkSub', 'mode', 'stn',
@@ -763,7 +763,7 @@ def convertitPreamble(file, output_encoding='utf-8'):  # set up elementTree
 
 
 
-def convertitPostamble(file, output_encoding='utf-8'):
+def convertitPostamble(fname, output_encoding='utf-8'):
    global outXMLFile
    if outXMLFile is None:
        return
@@ -772,7 +772,7 @@ def convertitPostamble(file, output_encoding='utf-8'):
    #                   'LATIN1' 'ISO-LATIN-1' 'ISO-8859-1' 'ASCII' 'cp500' 'cp037' 'UTF-7'
    #                   'windows-1252' 'UTF-8'
    treeTop = stack.takeTreeAndClear()
-   treeTop.write(outXMLFile, pretty_print=True, xml_declaration=True, encoding=output_encoding)
+   treeTop.write(fname, pretty_print=True, xml_declaration=True, encoding=output_encoding)
 
 
 def convertit(item, lineNumber):
@@ -980,15 +980,14 @@ def convertit(item, lineNumber):
 # generator to just read lines one by one
 #
 
-def doNotSplitRadar(file, input_encoding='utf-8'):
+def doNotSplitRadar(fname, input_encoding='utf-8'):
    global nSplit
    global splitLines
    global lineNumber
    nSplit = 0
    splitLines = []
    lineNumber = 0
-   # with open(fname) as f:
-   with open(file, "r", encoding=input_encoding) as f:
+   with open(fname, "r", encoding=input_encoding) as f:
       for l in f:
          lineNumber += 1
          yield l[0:81]

--- a/Python/bin/psvtoxml.py
+++ b/Python/bin/psvtoxml.py
@@ -539,9 +539,12 @@ def psvtoxml(psvfile, xmlfile, psvencoding="UTF-8", xmlencoding="UTF-8"):
 
 #----------------------------------------------------
 if __name__ == '__main__':
+  # construct argument parser for a conversion tool
    parser = convertutility.conversion_parser(
       description='Convert ADES PSV to XML.', 
    )
    args = parser.parse_args()
+   # create callable
    call = lambda i, o : psvtoxml(i, o, psvencoding=args.input_encoding, xmlencoding=args.output_encoding)
+   # call function with filename arguments
    convertutility.call_with_files(call, args)

--- a/Python/bin/psvtoxml.py
+++ b/Python/bin/psvtoxml.py
@@ -24,6 +24,7 @@ import argparse
 import sys
 
 import adesutility
+import convertutility
 
 
 #
@@ -519,7 +520,7 @@ def parsePSV(parsedPSVLine):
 # Main routine
 def psvtoxml(psvfile, xmlfile, psvencoding="UTF-8", xmlencoding="UTF-8"):
 
-   with io.open(psvfile, encoding=psvencoding) as f:
+   with open(psvfile, encoding=psvencoding) as f:
       lineNumber = 0
       for line in f:
          try:
@@ -538,12 +539,9 @@ def psvtoxml(psvfile, xmlfile, psvencoding="UTF-8", xmlencoding="UTF-8"):
 
 #----------------------------------------------------
 if __name__ == '__main__':
-   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-   parser.add_argument("psvfile", type=str, help="PSV file to convert to XML")
-   parser.add_argument("xmlfile", type=str, help="Path to write XML data to")
-   parser.add_argument("--psvencoding", default="UTF-8", type=str, help="Text encoding for PSV input")
-   parser.add_argument("--xmlencoding", default="UTF-8", type=str, help="Text encoding for XML output")
-
+   parser = convertutility.conversion_parser(
+      description='Convert ADES PSV to XML.', 
+   )
    args = parser.parse_args()
-
-   psvtoxml(args.psvfile, args.xmlfile, args.psvencoding, args.xmlencoding)
+   call = lambda i, o : psvtoxml(i, o, psvencoding=args.input_encoding, xmlencoding=args.output_encoding)
+   convertutility.call_with_files(call, args)

--- a/Python/bin/valades.py
+++ b/Python/bin/valades.py
@@ -38,11 +38,15 @@ def valades(adesmaster, xsltschema, xmlfile):
 
 # ---------------------------------------------------------------
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description='Validate XML against ADES master and a chosen schema.', 
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument("adesmaster", type=str, help="ADES master xml")
     parser.add_argument("xsltschema", type=str, help="Schema definition file")
-    parser.add_argument("xmlfile", type=str, help="XML file to check against schema")
-
+    parser = convertutility.input_parser(parser, input_help="XML file to check against schema")
+    
     args = parser.parse_args()
-
-    valades(args.adesmaster, args.xsltschema, args.xmlfile)
+    
+    call = lambda i, o : valades(args.adesmaster, args.xsltschema, i)
+    convertutility.call_with_files(call, args)

--- a/Python/bin/valall.py
+++ b/Python/bin/valall.py
@@ -20,6 +20,7 @@ import argparse
 
 import adesutility
 from valutility import validate_xslts, validate_xml_declaration
+import convertutility
 
 #
 # This script validates an xml file against six different
@@ -58,8 +59,11 @@ def valall(xmlfile):
         
 # --------------------------------------------------------------
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument("xmlfile", type=str, help="XML file to check against schema")
-
+  parser = convertutility.input_parser(
+    description='Validate XML against all schemas', 
+    input_help="XML file to check against schema"
+  )
   args = parser.parse_args()
-  valall(args.xmlfile)
+  call = lambda i, o : valall(i)
+  convertutility.call_with_files(call, args)
+

--- a/Python/bin/valall.py
+++ b/Python/bin/valall.py
@@ -59,11 +59,14 @@ def valall(xmlfile):
         
 # --------------------------------------------------------------
 if __name__ == '__main__':
+  # construct argument parser for a validation tool (input only)
   parser = convertutility.input_parser(
     description='Validate XML against all schemas', 
     input_help="XML file to check against schema"
   )
   args = parser.parse_args()
+  # create callable
   call = lambda i, o : valall(i)
+  # call function with filename arguments
   convertutility.call_with_files(call, args)
 

--- a/Python/bin/valgeneral.py
+++ b/Python/bin/valgeneral.py
@@ -20,6 +20,7 @@ import argparse
 
 import adesutility
 from valutility import validate_xslt, validate_xml_declaration
+import convertutility
 
 #
 # This script validates an xml file against six different
@@ -59,8 +60,11 @@ def valgeneral(xmlfile):
   
 # ------------------------------------------------------------
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument("xmlfile", type=str, help="XML file to check against schema")
-
+  parser = convertutility.input_parser(
+    description='Validate XML against general schema', 
+    input_help="XML file to check against schema"
+  )
   args = parser.parse_args()
-  valgeneral(args.xmlfile)
+  call = lambda i, o : valgeneral(i)
+  convertutility.call_with_files(call, args)
+

--- a/Python/bin/valgeneral.py
+++ b/Python/bin/valgeneral.py
@@ -60,11 +60,14 @@ def valgeneral(xmlfile):
   
 # ------------------------------------------------------------
 if __name__ == '__main__':
+  # construct argument parser for a validation tool (input only)
   parser = convertutility.input_parser(
     description='Validate XML against general schema', 
     input_help="XML file to check against schema"
   )
   args = parser.parse_args()
+  # create callable
   call = lambda i, o : valgeneral(i)
+  # call function with filename arguments
   convertutility.call_with_files(call, args)
 

--- a/Python/bin/validate.py
+++ b/Python/bin/validate.py
@@ -28,6 +28,7 @@ import argparse
 
 import adesutility
 from valutility import validate_schema, validate_xml_declaration
+import convertutility
 
 #
 # Read in the schema
@@ -53,10 +54,14 @@ def validate(schemafile, xmlfile):
     
 # -------------------------------------------------------------------
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description='Validate XML', 
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument("schemafile", type=str, help="Schema definition file")
-    parser.add_argument("xmlfile", type=str, help="XML file to check against schema")
+    parser = convertutility.input_parser(parser, input_help="XML file to check against schema")
 
     args = parser.parse_args()
 
-    validate(args.schemafile, args.xmlfile)
+    call = lambda i, o : validate(args.schemafile, i)
+    convertutility.call_with_files(call, args)

--- a/Python/bin/validate.py
+++ b/Python/bin/validate.py
@@ -54,6 +54,7 @@ def validate(schemafile, xmlfile):
     
 # -------------------------------------------------------------------
 if __name__ == '__main__':
+    # construct argument parser for a validation tool (input only)
     parser = argparse.ArgumentParser(
         description='Validate XML', 
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -62,6 +63,7 @@ if __name__ == '__main__':
     parser = convertutility.input_parser(parser, input_help="XML file to check against schema")
 
     args = parser.parse_args()
-
+    # create callable
     call = lambda i, o : validate(args.schemafile, i)
+    # call function with filename arguments
     convertutility.call_with_files(call, args)

--- a/Python/bin/valsubmit.py
+++ b/Python/bin/valsubmit.py
@@ -20,6 +20,8 @@ import argparse
 
 import adesutility
 from valutility import validate_xslt, validate_xml_declaration
+import io, convertutility
+import tempfile
 
 #
 # This script validates an xml file against six different
@@ -47,6 +49,7 @@ def valsubmit(xmlfile):
   #
   # read in file to be validataed
   #
+  
   candidate = adesutility.readXML(xmlfile)
   #
   # validate against submit schemaxslt files
@@ -57,9 +60,12 @@ def valsubmit(xmlfile):
   
 # --------------------------------------------------------
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument("xmlfile", type=str, help="XML file to check against schema")
+  parser = convertutility.input_parser(
+    description='Validate XML against submit schema', 
+    input_help="XML file to check against schema",
+  )
 
   args = parser.parse_args()
 
-  valsubmit(args.xmlfile)
+  call = lambda i, o : valsubmit(i)
+  convertutility.call_with_files(call, args)

--- a/Python/bin/valsubmit.py
+++ b/Python/bin/valsubmit.py
@@ -21,7 +21,6 @@ import argparse
 import adesutility
 from valutility import validate_xslt, validate_xml_declaration
 import io, convertutility
-import tempfile
 
 #
 # This script validates an xml file against six different
@@ -60,6 +59,7 @@ def valsubmit(xmlfile):
   
 # --------------------------------------------------------
 if __name__ == '__main__':
+  # construct argument parser for a validation tool (input only)
   parser = convertutility.input_parser(
     description='Validate XML against submit schema', 
     input_help="XML file to check against schema",
@@ -67,5 +67,7 @@ if __name__ == '__main__':
 
   args = parser.parse_args()
 
+  # create callable
   call = lambda i, o : valsubmit(i)
+  # call function with filename arguments
   convertutility.call_with_files(call, args)

--- a/Python/bin/valutility.py
+++ b/Python/bin/valutility.py
@@ -9,6 +9,8 @@ import argparse
 import re
 
 import adesutility
+import convertutility
+import io
 
 
 def validate_schema(schema_name, schema, candidate, out):

--- a/Python/bin/xmltojson.py
+++ b/Python/bin/xmltojson.py
@@ -11,21 +11,22 @@ import xmltodict
 import json
 import argparse
 from collections import OrderedDict  # Only necessary for python < 3.7
+import convertutility
+import sys
 
-def xmltojson(xmlfile, jsonfile, xmlencoding="utf-8"):
+
+def xmltojson(xmlfile, jsonfile, xmlencoding="utf-8", jsonencoding="utf-8"):
     """ """
-    with open(xmlfile, 'rb') as xf, open(jsonfile, 'w') as jf:
-        json.dump(xmltodict.parse(xf.read().decode(xmlencoding), dict_constructor=OrderedDict), jf, indent=4)
+    with open(xmlfile, 'rb') as xf, open(jsonfile, 'w', encoding=jsonencoding) as jf:
+        json.dump(xmltodict.parse(xf.read().decode(xmlencoding), dict_constructor=OrderedDict), jf, indent=4, ensure_ascii=False)
 
 
 if __name__ == '__main__':
-
     # read command line arguments
-    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("xmlfile", type=str, help="XML file to convert to JSON")
-    parser.add_argument("jsonfile", type=str, help="Path to write JSON data to")
-    parser.add_argument("--xmlencoding", default="utf-8", type=str, help="Text encoding for XML input")
+    parser = convertutility.conversion_parser(
+        description='Convert ADES XML to JSON', 
+    )
     args = parser.parse_args()
-
     # call function to read xml into a dict and then write to json
-    xmltojson(args.xmlfile, args.jsonfile, xmlencoding=args.xmlencoding)
+    call = lambda i, o : xmltojson(i, o, xmlencoding=args.input_encoding, jsonencoding=args.output_encoding)
+    convertutility.call_with_files(call, args)

--- a/Python/bin/xmltojson.py
+++ b/Python/bin/xmltojson.py
@@ -23,10 +23,12 @@ def xmltojson(xmlfile, jsonfile, xmlencoding="utf-8", jsonencoding="utf-8"):
 
 if __name__ == '__main__':
     # read command line arguments
+    # construct argument parser for a conversion tool
     parser = convertutility.conversion_parser(
         description='Convert ADES XML to JSON', 
     )
     args = parser.parse_args()
     # call function to read xml into a dict and then write to json
     call = lambda i, o : xmltojson(i, o, xmlencoding=args.input_encoding, jsonencoding=args.output_encoding)
+    # call function with filename arguments
     convertutility.call_with_files(call, args)

--- a/Python/bin/xmltompc80col.py
+++ b/Python/bin/xmltompc80col.py
@@ -459,6 +459,7 @@ def xmltompc80col(xmlfile, mpcencdoing='utf-8'):
 # --- Start executable code -----------------------------
 if __name__ == '__main__':
    # Input arguments
+   # construct argument parser for a conversion tool
    parser = convertutility.conversion_parser(
       description='Convert ADES XML to MPC obs80 format.', 
       input_help="XML file name", 
@@ -478,10 +479,12 @@ if __name__ == '__main__':
       defaultPrecTime = '10'
       defaultPrecRA = '0.01'
       defaultPrecDec = '0.1'
-   
+
+   # create callable
    def call(i, o):
       global encodedout
       with open(o, "w", encoding=args.output_encoding) as encodedout:
          xmltompc80col(i)
    
+   # call function with filename arguments
    convertutility.call_with_files(call, args)

--- a/Python/bin/xmltompc80col.py
+++ b/Python/bin/xmltompc80col.py
@@ -16,6 +16,8 @@ import argparse
 import adesutility
 import packUtil
 import sexVals
+import convertutility
+
 
 def setFromElementDictList(element,allowedElementDict):
    """ makes a set from the allowedElementDict list for elemnt """
@@ -437,11 +439,11 @@ def processObsContext(element):
   
 #----------------------------------------------------------------------
 #Main routine
-def xmltompc80col(xmlfile):
+def xmltompc80col(xmlfile, mpcencdoing='utf-8'):
+   global encodedout
    #
    # read in allowedElementDict, requiredElementDict  and psvFormatDict
    #
-
    (allowedElementDict, requiredElementDict, psvFormatDict) = \
       adesutility.getAdesTables()
 
@@ -457,9 +459,11 @@ def xmltompc80col(xmlfile):
 # --- Start executable code -----------------------------
 if __name__ == '__main__':
    # Input arguments
-   parser = argparse.ArgumentParser(description='Convert ADES XML to MPC obs80 format.')
-   parser.add_argument("xml", help = "XML file name")
-   parser.add_argument("obs80", help = "obs80 file name")
+   parser = convertutility.conversion_parser(
+      description='Convert ADES XML to MPC obs80 format.', 
+      input_help="XML file name", 
+      output_help="obs80 file name",
+   )
    parser.add_argument("--lowPrec", action='store_true', \
                        help= "Export Time, RA, and DEC in lower precision.")
    parser.add_argument("--noHeader", action='store_true', \
@@ -475,7 +479,9 @@ if __name__ == '__main__':
       defaultPrecRA = '0.01'
       defaultPrecDec = '0.1'
    
-   # Open output file
-   encodedout = io.open(args.obs80, 'w', encoding='utf-8')
-
-   xmltompc80col(args.xml)
+   def call(i, o):
+      global encodedout
+      with open(o, "w", encoding=args.output_encoding) as encodedout:
+         xmltompc80col(i)
+   
+   convertutility.call_with_files(call, args)

--- a/Python/bin/xmltopsv.py
+++ b/Python/bin/xmltopsv.py
@@ -320,7 +320,10 @@ def xmltopsv(xmlfile, psvfile, psvencoding="UTF-8"):
       processAdesElement(inputTree.getroot())
    
 if __name__ == "__main__":
+   # construct argument parser for a conversion tool
    parser = convertutility.conversion_parser(description="Convert ADES XML to PSV")
    args = parser.parse_args()
+   # create callable
    call = lambda i, o : xmltopsv(i, o, psvencoding=args.output_encoding)
+   # call function with filename arguments
    convertutility.call_with_files(call, args)

--- a/Python/bin/xmltopsv.py
+++ b/Python/bin/xmltopsv.py
@@ -14,6 +14,8 @@ import io
 
 from collections import OrderedDict
 
+import convertutility
+
 #
 # write encoded output for psv.  Default encoding
 # for psv is utf-8
@@ -311,21 +313,14 @@ allowedObsDataSet = setFromElementDictList('obsData')
 allowedObsBlockSet = setFromElementDictList('obsBlock')
 allowedAdesSet = setFromElementDictList('ades')
 
-
 def xmltopsv(xmlfile, psvfile, psvencoding="UTF-8"):
    global encodedout
    inputTree = adesutility.readXML(xmlfile)
-   encodedout = io.open(psvfile, 'w', encoding=psvencoding)
-   processAdesElement(inputTree.getroot())
-   encodedout.close()
+   with open(psvfile, 'w', encoding=psvencoding) as encodedout:
+      processAdesElement(inputTree.getroot())
    
-
 if __name__ == "__main__":
-   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-   parser.add_argument("xmlfile", type=str, help="XML file to convert to PSV")
-   parser.add_argument("psvfile", type=str, help="Path to write PSV data to")
-   parser.add_argument("--psvencoding", default="UTF-8", type=str, help="Text encoding for PSV output")
-
+   parser = convertutility.conversion_parser(description="Convert ADES XML to PSV")
    args = parser.parse_args()
-
-   xmltopsv(args.xmlfile, args.psvfile, psvencoding=args.psvencoding)
+   call = lambda i, o : xmltopsv(i, o, psvencoding=args.output_encoding)
+   convertutility.call_with_files(call, args)

--- a/new_tests/test_piping.py
+++ b/new_tests/test_piping.py
@@ -1,0 +1,44 @@
+import pytest
+import subprocess
+import os
+
+master_dir =  os.path.dirname(os.path.dirname(__file__))
+bin_dir = os.path.join(master_dir, "Python/bin")
+test_dir = os.path.join(master_dir, "new_tests")
+input_dir = os.path.join(test_dir, "input")
+output_dir = os.path.join(test_dir, "output")
+
+conversions = [
+    ("xmltojson.py", "319.xml", "319.json"),
+    ("jsontoxml.py", "319.json", "319.xml"),
+    ("mpc80coltoxml.py", "K20Q04A_test.obs", "K20Q04A_test.xml"),
+    ("psvtoxml.py", "2023MQ5.psv", "2023MQ5.xml"),
+    ("psvtoxml.py", "2023MQ5.psv", "2023MQ5.xml"),
+    ("xmltompc80col.py", "trksub_sub.xml", "trksub_sub.obs"),
+]
+
+@pytest.mark.parametrize("executable,in_filename,out_filename", conversions)
+def test_pipe_executables(executable, in_filename, out_filename):
+    in_path = os.path.join(input_dir, in_filename)
+    out_path = os.path.join(output_dir, out_filename)
+    with open(in_path, "rb") as in_file, open(out_path, "w") as out_file:
+        p = subprocess.run(os.path.join(bin_dir, executable), input=in_file.read(), stdout=out_file)
+    
+    assert(os.path.exists(out_path) and os.stat(out_path).st_size != 0)
+
+validation = [
+    ("valall.py", "obs_v2022.xml", []),
+    ("valgeneral.py", "obs_v2022.xml", []),
+    ("valsubmit.py", "obs_v2022.xml", []),
+    ("validate.py", "obs_v2022.xml", [os.path.join(master_dir, "xsd", "general.xsd")]),
+    ("validate.py", "obs.xml", [os.path.join(master_dir, "past_versions", "v2017", "general_v2017.xsd")]),
+]
+
+@pytest.mark.parametrize("executable,in_filename,args", validation)
+def test_pipe_validation(executable, in_filename, args):
+    in_path = os.path.join(input_dir, in_filename)
+    with open(in_path, "rb") as in_file:
+        p = subprocess.Popen([os.path.join(bin_dir, executable)] + args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate(input=in_file.read())
+
+    assert(b'is OK' in out and err == b'')


### PR DESCRIPTION
This PR allows Python conversion tools (files named `*to*.py`) to read from `stdin` and write to `stdout`. Additionally, it enforces input/output text encodings where they were previously not enforced. Tests are added in `test_piping.py`. Addresses issue #44 .