### PR TITLE
Sex vals bug

### DIFF
--- a/Python/bin/sexVals.py
+++ b/Python/bin/sexVals.py
@@ -64,14 +64,6 @@ _checkIntegerSeconds = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2})\s+(\d{1,2})\s*$')
 _checkMinutesHundredths = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2}\.\d{2})\s*$')
 _checkMinutesTenths = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2}\.\d)\s*$')
 _checkIntegerMinutes = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2})\s*$')
-##
-## Sexagesimal Parsing
-##
-#_checkNormal = re.compile(r'^(\d\d) (\d\d) (\d\d\.(\d*)) *$')
-#_checkIntegerSeconds = re.compile(r'^(\d\d) (\d\d) (\d\d) *$')
-#_checkMinutesHundredths = re.compile(r'^(\d\d) (\d\d\.\d\d) *$')
-#_checkMinutesTenths = re.compile(r'^(\d\d) (\d\d\.\d) *$')
-#_checkIntegerMinutes = re.compile(r'^(\d\d) (\d\d) *$')
 
 _countNormal = 0
 _countIntegerSeconds = 0

--- a/Python/bin/sexVals.py
+++ b/Python/bin/sexVals.py
@@ -57,13 +57,21 @@ def valueError(s, line, c1, c2, value=None):
                    ' must be blank not "' + s + '"', line)
 
 #
-# Sexagesimal Parsing
+# Sexagesimal Parsing (relaxed to allow leading spaces or single-digit fields)
 #
-_checkNormal = re.compile(r'^(\d\d) (\d\d) (\d\d\.(\d*)) *$')
-_checkIntegerSeconds = re.compile(r'^(\d\d) (\d\d) (\d\d) *$')
-_checkMinutesHundredths = re.compile(r'^(\d\d) (\d\d\.\d\d) *$')
-_checkMinutesTenths = re.compile(r'^(\d\d) (\d\d\.\d) *$')
-_checkIntegerMinutes = re.compile(r'^(\d\d) (\d\d) *$')
+_checkNormal = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2})\s+(\d{1,2}\.(\d*))\s*$')
+_checkIntegerSeconds = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2})\s+(\d{1,2})\s*$')
+_checkMinutesHundredths = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2}\.\d{2})\s*$')
+_checkMinutesTenths = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2}\.\d)\s*$')
+_checkIntegerMinutes = re.compile(r'^\s*(\d{1,2})\s+(\d{1,2})\s*$')
+##
+## Sexagesimal Parsing
+##
+#_checkNormal = re.compile(r'^(\d\d) (\d\d) (\d\d\.(\d*)) *$')
+#_checkIntegerSeconds = re.compile(r'^(\d\d) (\d\d) (\d\d) *$')
+#_checkMinutesHundredths = re.compile(r'^(\d\d) (\d\d\.\d\d) *$')
+#_checkMinutesTenths = re.compile(r'^(\d\d) (\d\d\.\d) *$')
+#_checkIntegerMinutes = re.compile(r'^(\d\d) (\d\d) *$')
 
 _countNormal = 0
 _countIntegerSeconds = 0


### PR DESCRIPTION
Allow less strict syntax checking on sexagesimal form, allowing leading zeros (in HH, MM, or SS.ssss) to be blanks.

So a string like, `13 57  8.2520` will now pass, even if it is not strictly compliant with obs80.