### PR TITLE
Add submission param to mpc80coltoxml to omit non-submit-schema elements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,6 @@
+18-Feb-2026 - Added `submission` option to `mpc80coltoxml`
+       # Allow users to turn an 80col file into an XML file that is valid for submission.
+
 22-Dec-2025 - Changed the length of the obssubID field from 25 to 35 chars 
        # Allow submission of old-style provIDs (e.g. A988 CA)
        # Some clean-up

--- a/tests/test_mpc80coltoxml.py
+++ b/tests/test_mpc80coltoxml.py
@@ -8,6 +8,7 @@ import pytest
 import os
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 
 from ades import mpc80coltoxml
 
@@ -65,4 +66,65 @@ def test_mpc80coltoxml_submitted_split_routine():
         os.remove(xmlfile)
     mpc80coltoxml.mpc80coltoxml(obsfile, xmlfile, nosplit=False)
     assert(os.path.exists(xmlfile))
+
+# ------------------ Testing submission mode ------------------
+
+# Elements that should be omitted when submission=True
+_non_submission_elements = {'subFmt', 'precTime', 'precRA', 'precDec'}
+
+def _get_xml_element_tags(xmlfile):
+    """Return the set of all element tag names in an XML file."""
+    tree = ET.parse(xmlfile)
+    return {elem.tag for elem in tree.iter()}
+
+def test_mpc80coltoxml_submission_false_has_non_submit_elements():
+    """Default mode (submission=False) should include subFmt, precTime, etc."""
+    obsfile = "input/K20Q04A_test.obs"
+    xmlfile = "output/K20Q04A_test_submission_false.xml"
+    if os.path.exists(xmlfile):
+        os.remove(xmlfile)
+    mpc80coltoxml.mpc80coltoxml(obsfile, xmlfile, submission=False)
+    assert os.path.exists(xmlfile) and os.stat(xmlfile).st_size != 0
+    tags = _get_xml_element_tags(xmlfile)
+    for elem in _non_submission_elements:
+        assert elem in tags, f"{elem} should be present when submission=False"
+
+def test_mpc80coltoxml_submission_true_omits_non_submit_elements():
+    """Submission mode (submission=True) should omit subFmt, precTime, etc."""
+    obsfile = "input/K20Q04A_test.obs"
+    xmlfile = "output/K20Q04A_test_submission_true.xml"
+    if os.path.exists(xmlfile):
+        os.remove(xmlfile)
+    mpc80coltoxml.mpc80coltoxml(obsfile, xmlfile, submission=True)
+    assert os.path.exists(xmlfile) and os.stat(xmlfile).st_size != 0
+    tags = _get_xml_element_tags(xmlfile)
+    for elem in _non_submission_elements:
+        assert elem not in tags, f"{elem} should be absent when submission=True"
+
+def test_mpc80coltoxml_submission_true_preserves_core_elements():
+    """Submission mode should preserve core observation elements."""
+    obsfile = "input/K20Q04A_test.obs"
+    xmlfile = "output/K20Q04A_test_submission_core.xml"
+    if os.path.exists(xmlfile):
+        os.remove(xmlfile)
+    mpc80coltoxml.mpc80coltoxml(obsfile, xmlfile, submission=True)
+    assert os.path.exists(xmlfile) and os.stat(xmlfile).st_size != 0
+    tags = _get_xml_element_tags(xmlfile)
+    for elem in ['ra', 'dec', 'mag', 'stn', 'obsTime', 'astCat', 'band']:
+        assert elem in tags, f"{elem} should be preserved when submission=True"
+
+def test_mpc80coltoxml_submission_cli():
+    """CLI --submission flag should omit non-submission elements."""
+    obsfile = "input/K20Q04A_test.obs"
+    xmlfile = "output/K20Q04A_test_submission_cli.xml"
+    if os.path.exists(xmlfile):
+        os.remove(xmlfile)
+    subprocess.run(
+        [sys.executable, "-m", "ades.mpc80coltoxml", "--submission", obsfile, xmlfile],
+        check=True,
+    )
+    assert os.path.exists(xmlfile) and os.stat(xmlfile).st_size != 0
+    tags = _get_xml_element_tags(xmlfile)
+    for elem in _non_submission_elements:
+        assert elem not in tags, f"{elem} should be absent with --submission CLI flag"
 


### PR DESCRIPTION
Prior to this PR, the `mpc80coltoxml` will populate elements such `subFmt`, `precTime`, `precRA`, etc that are generally valid, but are *NOT* valid for submission to the MPC. 

I'd like the ades repo to have the functionality to allow people take an 80col file and turn it into a XML **that is valid for submission** if they so desire. 

One way we could do this is as per this PR: 
 - I've added a `submission` option to `mpc80coltoxml`
 - `submission` defaults to `False`, so it's behavior defaults to the current mode, and all elements such `subFmt`, `precTime`, `precRA`, etc, will continue to be made by default 
 - If the user passes `submission=True` to the `mpc80coltoxml` function, then elements such as `subFmt`, `precTime`, `precRA`,  etc, will be omitted from the XML, allowing it to pass validation

I've also 
 - Added --submission CLI flag. 
 - Provided a few more unit tests of the new option

One imagines that I should also add some text to the README, but I'll wait on that until after some folks have reviewed this ... 
